### PR TITLE
fix: Suppress Clang nullability warnings for protobuf sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,3 +175,14 @@ target_include_directories(nsb_test PUBLIC
     ${Protobuf_INCLUDE_DIRS}
     ${YAML_CPP_INCLUDE_DIR}
 )
+
+# Suppress Clang-specific nullability-extension warning which can be emitted
+# by protobuf-generated sources (these use Clang nullability annotations).
+# The project enables -Werror globally, so treat this as a safe, targeted
+# suppression for Clang/AppleClang only on the targets that build generated
+# protobuf code.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+    target_compile_options(nsb PRIVATE "-Wno-nullability-extension")
+    target_compile_options(nsb_daemon PRIVATE "-Wno-nullability-extension")
+    target_compile_options(nsb_test PRIVATE "-Wno-nullability-extension")
+endif()

--- a/python/nsb_client.py
+++ b/python/nsb_client.py
@@ -12,6 +12,7 @@ import threading
 import redis
 
 import random
+from typing import Optional
 
 ## @cond
 logging.basicConfig(level=logging.INFO,
@@ -251,7 +252,7 @@ class SocketInterface(Comms):
         else:
             self.logger.error("Socket not ready to send, cannot send message.")
 
-    def _recv_msg(self, channel:Comms.Channels, timeout:int|None=None):
+    def _recv_msg(self, channel:Comms.Channels, timeout:Optional[int]=None):
         """
         @brief Receives a message from the server.
         
@@ -699,7 +700,7 @@ class NSBAppClient(NSBClient):
         self.logger.info("SEND: Sent message + payload to server.")
         return key
 
-    def receive(self, dest_id:str|None=None, timeout:int|None=None):
+    def receive(self, dest_id:Optional[str]=None, timeout:Optional[int]=None):
         """
         @brief Receives a payload via NSB.
 
@@ -857,7 +858,7 @@ class NSBSimClient(NSBClient):
         self.og_indicator = nsb_pb2.nsbm.Manifest.Originator.SIM_CLIENT
         self.initialize()
 
-    def fetch(self, src_id:str|None=None, timeout=None):
+    def fetch(self, src_id:Optional[str]=None, timeout=None):
         """
         @brief Fetches a payload that needs to be sent over the simulated 
                network.


### PR DESCRIPTION
- This PR fixes a build issue on Clang/AppleClang compilers that arises from protobuf-generated code.
- The project uses `-Werror`, which was causing the build to fail due to the `-Wnullability-extension` warning emitted by Clang when processing the nullability annotations in the protobuf-generated header files.