### PR TITLE
fix: Ensure metadata is always initialized in fetch()

### DIFF
--- a/cpp/src/nsb_client.cc
+++ b/cpp/src/nsb_client.cc
@@ -284,10 +284,11 @@ namespace nsb {
             mutableManifest->set_op(nsb::nsbm::Manifest::FETCH);
             mutableManifest->set_og(*originIndicator);
             mutableManifest->set_code(nsb::nsbm::Manifest::SUCCESS);
+            nsb::nsbm::Metadata* mutableMetadata = nsbMsg->mutable_metadata();
             if (cfg.SIMULATOR_MODE == Config::SimulatorMode::SYSTEM_WIDE) {
                 if (srcId != nullptr) {
                     // If target source ID has been set, specify that. 
-                    nsbMsg->mutable_metadata()->set_src_id(*srcId);
+                    mutableMetadata->set_src_id(*srcId);
                 } // Otherwise, we can leave it unspecified.
             } else if (cfg.SIMULATOR_MODE == Config::SimulatorMode::PER_NODE) {
                 if (srcId != nullptr) {
@@ -295,7 +296,7 @@ namespace nsb {
                         << "Simulation mode is set to PER_NODE, so specified target source will be overwritten."
                         << std::endl;
                 }
-                nsbMsg->mutable_metadata()->set_src_id(clientId);
+                mutableMetadata->set_src_id(clientId);
             }
             // Send the message.
             DLOG(INFO) << "FETCH: Sending request:" << std::endl << nsbMsg->DebugString();

--- a/cpp/src/nsb_daemon.cc
+++ b/cpp/src/nsb_daemon.cc
@@ -302,7 +302,7 @@ namespace nsb {
     void NSBDaemon::handle_send(nsb::nsbm* incoming_msg, nsb::nsbm* outgoing_msg, bool* response_required) {
         *response_required = false;
         LOG(INFO) << "Handling SEND message from client " 
-                << incoming_msg->intro().identifier() << " in ";
+                << incoming_msg->intro().identifier() << " in " << std::endl;
         if (cfg.SYSTEM_MODE == Config::SystemMode::PULL) {
             LOG(INFO).NoPrefix() << "PULL mode..." << std::endl;
             // Parse the metadata.
@@ -418,7 +418,7 @@ namespace nsb {
     void NSBDaemon::handle_post(nsb::nsbm* incoming_msg, nsb::nsbm* outgoing_msg, bool* response_required) {
         *response_required = false;
         LOG(INFO) << "Handling POST message from client " 
-                << incoming_msg->intro().identifier() << " in ";
+                << incoming_msg->intro().identifier() << " in " << std::endl;
         if (cfg.SYSTEM_MODE == Config::SystemMode::PULL) {
             LOG(INFO).NoPrefix() << "PULL mode..." << std::endl;
             // Check for message.


### PR DESCRIPTION
## Problem
In `NSBSimClient::fetch()`, metadata could be uninitialized if:
- System mode = PULL
- Simulator mode = SYSTEM_WIDE
- srcId = null

This left metadata in an undefined state for later operations.

## Solution
Always call `mutable_metadata()` upfront to ensure the metadata object
exists before conditionally setting fields.

## Changes
- `nsb/cpp/src/nsb_client.cc` - Initialize metadata at start of fetch()