### PR TITLE
Make recv non-blocking for macOS and Linux compatibility

### DIFF
--- a/cpp/src/nsb.cc
+++ b/cpp/src/nsb.cc
@@ -141,11 +141,11 @@ namespace nsb {
                 return std::string();
             } else {
                 // Read buffer until there's nothing left.
-                int bytesRead = recv(*fdPtr, buffer, RECEIVE_BUFFER_SIZE-1, 0);
+                int bytesRead = recv(*fdPtr, buffer, RECEIVE_BUFFER_SIZE-1, MSG_DONTWAIT);
                 while (bytesRead > 0) {
                     messageExists = true;
                     message.append(buffer, bytesRead);
-                    bytesRead = recv(*fdPtr, buffer, RECEIVE_BUFFER_SIZE-1, 0);
+                    bytesRead = recv(*fdPtr, buffer, RECEIVE_BUFFER_SIZE-1, MSG_DONTWAIT);
                 }
                 if (messageExists) {
                     return message;

--- a/cpp/src/nsb_daemon.cc
+++ b/cpp/src/nsb_daemon.cc
@@ -127,12 +127,12 @@ namespace nsb {
                         char buffer[MAX_BUFFER_SIZE];
                         std::vector<char> message;
                         // Read buffer until there's nothing left.
-                        int bytes_read = recv(fd, buffer, sizeof(buffer)-1, 0);
+                        int bytes_read = recv(fd, buffer, sizeof(buffer)-1, MSG_DONTWAIT);
                         while(bytes_read > 0) {
                             message_exists = true;
                             DLOG(INFO) << "Picked up " << bytes_read << "B from FD " << fd << "." << std::endl;
                             message.insert(message.end(), buffer, buffer+bytes_read);
-                            bytes_read = recv(fd, buffer, sizeof(buffer)-1, 0);
+                            bytes_read = recv(fd, buffer, sizeof(buffer)-1, MSG_DONTWAIT);
                         }
                         if (message_exists) {
                             DLOG(INFO) << "Received message from FD " << fd << ": " << 


### PR DESCRIPTION
This PR updates the socket `recv()` call to use `MSG_DONTWAIT`, making reads non-blocking and improving cross-platform behavior on macOS and Linux.

## Change
- Switch from blocking `recv(..., 0)` to non-blocking `recv(..., MSG_DONTWAIT)`:
- Prevents the read from blocking the thread when no data is available.

## Notes
When no data is available, `recv()` may return `-1` with `EAGAIN`/`EWOULDBLOCK`.