### PR TITLE
fix: resolve build failures on Ubuntu 22.04 with standard toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ message(STATUS "Proto File directory: ${PROTO_DIR}")
 
 # Get necessary packages.
 find_package(absl REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf REQUIRED CONFIG)
 find_package(yaml-cpp REQUIRED)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 # Use pkg-config for hiredis due to this issue (https://github.com/coturn/coturn/issues/1618)

--- a/cpp/include/nsb.h
+++ b/cpp/include/nsb.h
@@ -17,7 +17,6 @@
 #include <iomanip>
 #include <chrono>
 #include <cstdio>
-#include <format>
 #include <signal.h>
 #include <future>
 // Networking libraries.

--- a/cpp/src/nsb_daemon.cc
+++ b/cpp/src/nsb_daemon.cc
@@ -372,7 +372,7 @@ namespace nsb {
         // Check to see if source has been specified.
         if (incoming_msg->has_metadata()) {
             nsb::nsbm::Metadata in_metadata = incoming_msg->metadata();
-            if (in_metadata.has_src_id()) {
+            if (!in_metadata.src_id().empty()) {
                 // Search for the message in the buffer.
                 auto it = std::find_if(tx_buffer.begin(), tx_buffer.end(),
                           [&](const auto& msg) { return msg.source == in_metadata.src_id(); });
@@ -490,7 +490,7 @@ namespace nsb {
         // Check for destination.
         if (incoming_msg->has_metadata()) {
             nsb::nsbm::Metadata in_metadata = incoming_msg->metadata();
-            if (in_metadata.has_dest_id()) {
+            if (!in_metadata.dest_id().empty()) {
                 // Search for the message in the buffer.
                 auto it = std::find_if(rx_buffer.begin(), rx_buffer.end(),
                           [&](const auto& msg) { return msg.destination == in_metadata.dest_id(); });

--- a/proto/nsb.proto
+++ b/proto/nsb.proto
@@ -1,7 +1,5 @@
-edition = "2023";
-
+syntax = "proto3";
 package nsb;
-
 message nsbm {
     message Manifest {
         enum Operation {
@@ -22,7 +20,6 @@ message nsbm {
             SIM_CLIENT = 2;
         }
         Originator og = 2;
-
         enum OpCode {
             SUCCESS = 0;
             FAILURE = 1;
@@ -36,14 +33,12 @@ message nsbm {
         OpCode code = 3;
     }
     Manifest manifest = 1;
-
     message Metadata {
         string src_id = 1;
         string dest_id = 2;
         int32 payload_size = 3;
     }
     Metadata metadata = 2;
-
     message ConfigParams {
         enum SystemMode {
             PULL = 0;
@@ -60,7 +55,6 @@ message nsbm {
         int32 db_port = 5;
         int32 db_num = 6;
     }
-
     message IntroDetails {
         string identifier = 1;
         string address = 2;
@@ -68,7 +62,6 @@ message nsbm {
         int32 ch_SEND = 4;
         int32 ch_RECV = 5;
     }
-
     oneof message {
         bytes payload = 3;
         string msg_key = 4;


### PR DESCRIPTION
I was trying to build NSB on a fresh Ubuntu 22.04 install and hit a few issues that blocked the build from completing.

**1. proto/nsb.proto - switched from edition 2023 to proto3**
The proto file was using `edition = "2023"` which requires `--experimental_editions` and isn't supported by standard protoc. Converted to `syntax = "proto3"` , all the message types are fully compatible so there's no functional change.

**2. cpp/include/nsb.h - removed unused `<format>` include**
`<format>` was included but never used anywhere in the codebase. It also requires GCC 13+ which isn't the default on Ubuntu 22.04 (ships GCC 11), so it was breaking the build for no reason.

**3. cpp/src/nsb_daemon.cc - fixed string field checks for proto3**
`has_src_id()` and `has_dest_id()` don't get generated for scalar string fields in proto3. Replaced with `.empty()` checks which behave identically.

**4. CMakeLists.txt - CONFIG mode for find_package(Protobuf)**
Module mode was picking up the outdated system cmake FindProtobuf.cmake instead of protobuf's own config files. Switching to CONFIG mode fixes this.

Tested on Ubuntu 22.04 / GCC 11.4.0, libnsb.so, nsb_daemon, and nsb_test all build successfully.