### PR TITLE
feat: improve Python packaging with proper pyproject.toml, dependenci…

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,21 +1,33 @@
 # NSB Client API in Python
 
 ## Adding the Client Module
-_Installable Python package coming soon._
 
-To access the client module, we recommend directly just copying the contents 
-of this directory to your Python project and use it as a module within your 
-project.
+### Install via pip (Recommended)
 
-If you want to install the package in development mode and want it to be 
-accessible to other project spaces, you can install it. From this directory:
+You can install the NSB Python client library in development mode from the
+`python/` directory. This will also install the required dependencies
+(`protobuf` and `redis`):
 ```bash
+cd python/
 pip install -e .
 ```
-Then, add the full path to this module to your PYTHONPATH, and add that to your
-_.zshrc_ or _.bashrc_ file.
+
+To also install development and testing dependencies:
+```bash
+pip install -e ".[dev]"
 ```
-echo 'export PYTHONPATH="${PYTHONPATH}:/.../nsb_beta/python"' >> ~/.zshrc
+
+### Manual Setup (Alternative)
+
+Alternatively, you can copy the contents of this directory to your Python
+project and use it as a module. Make sure to install the required dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+If needed, add the full path to this module to your `PYTHONPATH`:
+```
+echo 'export PYTHONPATH="${PYTHONPATH}:/.../nsb/python"' >> ~/.zshrc
 ```
 
 ## Basic API Usage

--- a/python/proto/__init__.py
+++ b/python/proto/__init__.py
@@ -1,0 +1,3 @@
+# This file is intentionally left empty.
+# It marks the proto directory as a Python package so that the generated
+# protobuf modules (e.g. nsb_pb2) can be imported via `import proto.nsb_pb2`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,8 +1,36 @@
-# pyproject.toml
 [build-system]
-requires = ["setuptools", "protobuf", "redis[hiredis]"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "nsb_client"
+name = "nsb-client"
 version = "0.1.0"
+description = "Python client library for NSB – the Network Simulation Bridge"
+readme = "README.md"
+license = {text = "BSD-3-Clause"}
+requires-python = ">=3.7"
+authors = [
+    {name = "Inter-Networking Research Group, UC Santa Cruz"},
+]
+
+dependencies = [
+    "protobuf",
+    "redis[hiredis]",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[project.urls]
+Homepage = "https://github.com/nsb-ucsc/nsb_beta"
+Repository = "https://github.com/nsb-ucsc/nsb_beta"
+Issues = "https://github.com/nsb-ucsc/nsb_beta/issues"
+
+[tool.setuptools]
+py-modules = ["nsb_client"]
+
+[tool.setuptools.packages.find]
+include = ["proto*"]


### PR DESCRIPTION
## Problem

The current pyproject.toml is minimal and has a critical issue: the runtime
dependencies (protobuf, redis) are listed only under [build-system].requires,
which means they are not installed when a user runs pip install. This causes
import errors when attempting to use the NSB Python client.

## Changes

python/pyproject.toml
- Added protobuf and redis[hiredis] as runtime dependencies under [project].dependencies
- Added requires-python >= 3.7
- Added project metadata (description, license, authors, repository URLs)
- Added optional dev dependencies (pytest, pytest-asyncio) installable via pip install -e ".[dev]"
- Configured setuptools package discovery to include the proto subpackage

python/proto/__init__.py (new file)
- Marks the proto directory as a Python package, enabling import proto.nsb_pb2

python/README.md
- Replaced "Installable Python package coming soon" with working installation instructions
- Documented both pip install -e . (recommended) and manual setup (alternative) methods

## Testing

- Verified pip install -e . succeeds on both Windows and Ubuntu 24.04 (WSL)
- Confirmed pip show nsb-client displays correct metadata and dependencies
- Confirmed protobuf and redis are automatically installed as dependencies
