### PR TITLE
feat: add NSB manager CLI for service lifecycle management

### DIFF
--- a/nsb_manager.py
+++ b/nsb_manager.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Manage NSB services (Redis + daemon) from one place.
+
+    python nsb_manager.py start
+    python nsb_manager.py stop
+    python nsb_manager.py status
+    python nsb_manager.py restart
+"""
+
+import argparse
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+import yaml
+
+
+def load_config(path):
+    """Pull connection settings out of config.yaml."""
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+
+    sys_cfg = raw.get("system", {})
+    db_cfg = raw.get("database", {})
+
+    return {
+        "daemon_address": sys_cfg.get("daemon_address", "127.0.0.1"),
+        "daemon_port": int(sys_cfg.get("daemon_port", 65432)),
+        "system_mode": {0: "PULL", 1: "PUSH"}.get(sys_cfg.get("mode", 0), "PULL"),
+        "simulator_mode": {0: "System-Wide", 1: "Per-Node"}.get(sys_cfg.get("simulator_mode", 0)),
+        "use_db": db_cfg.get("use_db", True),
+        "db_address": db_cfg.get("db_address", "127.0.0.1"),
+        "db_port": int(db_cfg.get("db_port", 5050)),
+    }
+
+
+def is_port_open(port):
+    """Quick check if something is listening on a port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("127.0.0.1", port)) == 0
+
+
+def get_pid(port):
+    """Find the PID of whatever is listening on a port, if anything."""
+    try:
+        out = subprocess.check_output(
+            ["lsof", "-t", "-i", f":{port}"], stderr=subprocess.DEVNULL
+        )
+        first = out.decode().strip().split("\n")[0]
+        return int(first) if first else None
+    except (subprocess.CalledProcessError, ValueError):
+        return None
+
+
+def find_daemon(config_path):
+    """Look for the nsb_daemon binary in common locations."""
+    root = os.path.dirname(os.path.abspath(config_path))
+
+    for candidate in [
+        os.path.join(root, "build", "nsb_daemon"),
+        os.path.join(root, "nsb_daemon"),
+    ]:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+
+    # Maybe it's on the system PATH.
+    try:
+        return subprocess.check_output(
+            ["which", "nsb_daemon"], stderr=subprocess.DEVNULL
+        ).decode().strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
+# -- Commands --
+
+
+def start(cfg, config_path):
+    print("\n  Starting NSB services...\n")
+
+    # Start Redis (if enabled and not already running).
+    if is_port_open(cfg["db_port"]):
+        print(f"  Redis        already running on port {cfg['db_port']}")
+    elif cfg["use_db"]:
+        print(f"  Redis        starting on port {cfg['db_port']}...", end=" ")
+        try:
+            subprocess.run(
+                ["redis-server", "--port", str(cfg["db_port"]), "--daemonize", "yes"],
+                check=True, capture_output=True,
+            )
+            time.sleep(0.5)
+            print("✓" if is_port_open(cfg["db_port"]) else "✗ failed")
+        except FileNotFoundError:
+            print("✗ redis-server not found (apt install redis-server)")
+            return False
+    else:
+        print("  Redis        skipped (disabled in config)")
+
+    # Start daemon (if not already running).
+    if is_port_open(cfg["daemon_port"]):
+        print(f"  Daemon       already running on port {cfg['daemon_port']}")
+    else:
+        daemon = find_daemon(config_path)
+        if not daemon:
+            print("  Daemon       ✗ nsb_daemon not found — build NSB first")
+            return False
+
+        print(f"  Daemon       starting on port {cfg['daemon_port']}...", end=" ")
+        subprocess.Popen(
+            [daemon, os.path.abspath(config_path)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1)
+        print("✓" if is_port_open(cfg["daemon_port"]) else "✗ failed")
+
+    print("\n  NSB is ready.\n")
+    return True
+
+
+def stop(cfg):
+    print("\n  Stopping NSB services...\n")
+
+    # Stop daemon first.
+    pid = get_pid(cfg["daemon_port"])
+    if pid:
+        print(f"  Daemon       stopping (pid {pid})...", end=" ")
+        try:
+            os.kill(pid, signal.SIGTERM)
+            time.sleep(0.5)
+            print("✓")
+        except ProcessLookupError:
+            print("already gone")
+    else:
+        print("  Daemon       not running")
+
+    # Then stop Redis.
+    if is_port_open(cfg["db_port"]):
+        print(f"  Redis        stopping...", end=" ")
+        try:
+            subprocess.run(
+                ["redis-cli", "-p", str(cfg["db_port"]), "shutdown"],
+                check=True, capture_output=True,
+            )
+            print("✓")
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pid = get_pid(cfg["db_port"])
+            if pid:
+                os.kill(pid, signal.SIGTERM)
+                print("✓")
+            else:
+                print("✗")
+    else:
+        print("  Redis        not running")
+    print()
+
+
+def status(cfg):
+    print("\n  NSB Status")
+    print("  " + "─" * 40)
+
+    redis_up = is_port_open(cfg["db_port"])
+    daemon_up = is_port_open(cfg["daemon_port"])
+
+    r = "✓ Running" if redis_up else "✗ Stopped"
+    d = "✓ Running" if daemon_up else "✗ Stopped"
+
+    print(f"  Redis        port {cfg['db_port']}    {r}")
+    print(f"  Daemon       port {cfg['daemon_port']}  {d}")
+    print(f"  Mode         {cfg['system_mode']}")
+    print(f"  Simulator    {cfg['simulator_mode']}")
+    print(f"  Database     {'Enabled' if cfg['use_db'] else 'Disabled'}")
+    print()
+    return redis_up and daemon_up
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage NSB services.")
+    parser.add_argument("command", choices=["start", "stop", "status", "restart"])
+    parser.add_argument("-c", "--config", default="config.yaml",
+                        help="path to config.yaml (default: config.yaml)")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.config):
+        print(f"Error: '{args.config}' not found.")
+        print("Use -c to specify the config path.")
+        sys.exit(1)
+
+    cfg = load_config(args.config)
+
+    if args.command == "start":
+        sys.exit(0 if start(cfg, args.config) else 1)
+    elif args.command == "stop":
+        stop(cfg)
+    elif args.command == "status":
+        sys.exit(0 if status(cfg) else 1)
+    elif args.command == "restart":
+        stop(cfg)
+        time.sleep(1)
+        sys.exit(0 if start(cfg, args.config) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/test_nsb_client.py
+++ b/python/test_nsb_client.py
@@ -1,0 +1,156 @@
+"""
+Tests for the NSB Python client library.
+
+Unit tests can run standalone (no daemon/Redis needed):
+    pytest test_nsb_client.py -v -m "not integration"
+
+Full test suite (needs daemon + Redis running):
+    pytest test_nsb_client.py -v
+"""
+
+import pytest
+import threading
+
+from nsb_client import (
+    MessageEntry,
+    Config,
+    DBConnector,
+    RedisConnector,
+    Comms,
+)
+
+# Connection settings — change these if your setup uses different ports.
+DAEMON_ADDRESS = "127.0.0.1"
+DAEMON_PORT = 65432
+REDIS_ADDRESS = "127.0.0.1"
+REDIS_PORT = 5050
+
+
+# ── Unit Tests (no external services needed) ─────────────────────────────
+
+
+class TestMessageEntry:
+    """Verify that MessageEntry correctly stores message data."""
+
+    def test_basic_creation(self):
+        msg = MessageEntry("node0", "node1", b"hello world")
+        assert msg.src_id == "node0"
+        assert msg.dest_id == "node1"
+        assert msg.payload == b"hello world"
+
+    def test_payload_size_is_auto_computed(self):
+        payload = b"test payload data"
+        msg = MessageEntry("src", "dst", payload)
+        assert msg.payload_size == len(payload)
+
+    def test_empty_payload(self):
+        msg = MessageEntry("src", "dst", b"")
+        assert msg.payload == b""
+        assert msg.payload_size == 0
+
+    def test_handles_large_payloads(self):
+        big = b"x" * 100_000
+        msg = MessageEntry("src", "dst", big)
+        assert msg.payload_size == 100_000
+        assert msg.payload == big
+
+
+class TestDBConnector:
+    """Verify payload ID generation in DBConnector."""
+
+    def test_ids_are_unique(self):
+        db = DBConnector("client1")
+        ids = {db.generate_payload_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_id_includes_client_name(self):
+        db = DBConnector("my_node")
+        pid = db.generate_payload_id()
+        assert "my_node" in pid
+
+    def test_ids_unique_across_threads(self):
+        """Make sure concurrent ID generation doesn't produce duplicates."""
+        db = DBConnector("threaded")
+        results = []
+        lock = threading.Lock()
+
+        def generate(n):
+            for _ in range(n):
+                pid = db.generate_payload_id()
+                with lock:
+                    results.append(pid)
+
+        threads = [threading.Thread(target=generate, args=(50,)) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(set(results)) == 200
+
+class TestCommsChannels:
+    """Sanity check the channel enum values."""
+
+    def test_expected_values(self):
+        assert Comms.Channels.CTRL == 0
+        assert Comms.Channels.SEND == 1
+        assert Comms.Channels.RECV == 2
+
+    def test_three_channels_exist(self):
+        assert len(Comms.Channels) == 3
+
+
+# ── Integration Tests (need Redis running on port 5050) ──────────────────
+
+
+@pytest.mark.integration
+class TestRedisConnector:
+    """Verify that RedisConnector can store and retrieve payloads."""
+
+    @pytest.fixture(autouse=True)
+    def connect_to_redis(self):
+        try:
+            self.redis = RedisConnector("test_redis", REDIS_ADDRESS, REDIS_PORT)
+            if not self.redis.is_connected():
+                pytest.skip("Redis not running")
+        except Exception:
+            pytest.skip("Redis not running")
+
+    def test_peek_reads_without_deleting(self):
+        key = self.redis.store(b"peek me")
+        assert self.redis.peek(key) == b"peek me"
+        # Should still be there after peeking.
+        assert self.redis.peek(key) == b"peek me"
+        self.redis.check_out(key)  # clean up
+
+    def test_checkout_reads_and_deletes(self):
+        key = self.redis.store(b"one time read")
+        assert self.redis.check_out(key) == b"one time read"
+        # Gone after checkout.
+        assert self.redis.peek(key) is None
+
+    def test_binary_data_roundtrip(self):
+        """Payloads with non-UTF-8 bytes should survive store/retrieve."""
+        raw = bytes(range(256))
+        key = self.redis.store(raw)
+        assert self.redis.check_out(key) == raw
+
+
+# ── Lifecycle Tests (TODO) ───────────────────────────────────────────────
+#
+# Full send -> fetch -> post -> receive tests are planned but deferred.
+# They depend on daemon session handling that needs further investigation.
+#
+# Planned:
+#   - test_send_fetch_post_receive
+#   - test_receive_returns_none_when_empty
+#   - test_multiple_sequential_messages
+
+
+# ── pytest setup ─────────────────────────────────────────────────────────
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "integration: requires running NSB daemon and/or Redis server",
+    )


### PR DESCRIPTION
## Summary

Added a CLI tool to manage NSB services (Redis + daemon) from a single 
interface, replacing the need to manually run multiple commands across 
multiple terminals.

## Usage

    python nsb_manager.py start   -c config.yaml   # start Redis + daemon
    python nsb_manager.py stop    -c config.yaml   # stop all services
    python nsb_manager.py status  -c config.yaml   # check what's running
    python nsb_manager.py restart -c config.yaml   # restart everything

## What it does

- Reads config.yaml to determine ports and settings
- Starts/stops Redis and nsb_daemon as a pair
- Checks for port conflicts before starting
- Auto-discovers the nsb_daemon binary in build/ or system PATH
- Reports clear status with service state, ports, and config info

## Before vs After

Before (5 manual commands):
    redis-server --port 5050 --daemonize yes
    redis-cli -p 5050 ping
    cd build && ./nsb_daemon ../config.yaml &
    kill $(lsof -t -i:65432)
    redis-cli -p 5050 shutdown

After (1 command):
    python nsb_manager.py start -c config.yaml

## Testing

Verified on WSL Ubuntu 24.04. All services start, stop, and restart 
correctly. Client connectivity confirmed after manager-initiated startup.
