### PR TITLE
fix: correct broken C++ cout examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,10 @@ if (incoming_payload.exists()) {
     ...
 
     // You can access the payload properties.
-    std::cout << "Source: << incoming_payload.source\n" <<
-          "Destination: << incoming_payload.destination\n" <<
-          "Payload Size: << incoming_payload.payload_size\n" <<
-          "Payload: << incoming_payload.payload\n" << std::endl;
+    std::cout << "Source: " << incoming_payload.source << "\n"
+              << "Destination: " << incoming_payload.destination << "\n"
+              << "Payload Size: " << incoming_payload.payload_size << "\n"
+              << "Payload: " << incoming_payload.payload << std::endl;
 }
 ```
 


### PR DESCRIPTION
Fixed the cout statements in the NSBAppClient usage example. The << 
operators were inside the string quotes, so the code would print literal
text instead of variable values if copy-pasted.
