### PR TITLE
Fix: correct markdown link for Linux setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ _Coming soon._
 
 #### Linux
 
-_Check the [Linux-specific instructions](linux-setup-guide.md)._
+_Check the [Linux-specific instructions](./linux-setup-guide.md)._
 
 ## Basic Usage
 


### PR DESCRIPTION
## Problem
Linux setup guide link doesn't work in some markdown renderers.

## Solution
Added `./` prefix for explicit relative path:
- Before: `(linux-setup-guide.md)`
- After: `(./linux-setup-guide.md)`