### PR TITLE
docs: add Table of Contents to all README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@
   </tr>
 </table>
 
+## Table of Contents
+- [Contact & Collaborate](#contact--collaborate)
+- [Installation](#installation)
+  - [Prerequisites](#prerequisites)
+  - [Build](#build)
+  - [Uninstallation](#uninstallation)
+  - [MacOS via Homebrew](#macos-via-homebrew)
+  - [Windows via vcpkg](#windows-via-vcpkg)
+  - [Linux](#linux)
+- [Basic Usage](#basic-usage)
+  - [Programming Interface](#programming-interface)
+    - [Adding NSB in Projects](#adding-nsb-in-projects)
+    - [NSBAppClient Interface](#nsbappclient-interface)
+    - [NSBSimClient Interface](#nsbsimclient-interface)
+  - [System Configuration](#system-configuration)
+  - [Running Your System](#running-your-system)
+- [Extensibility](#extensibility)
+- [Acknowledgments](#acknowledgments)
+- [License](#_license---bsd_)
+
 ## Contact & Collaborate
 
 NSB was first created to address real research needs at the [Inter-Networking Research Group](https://inrg.engineering.ucsc.edu/) at the University of California, Santa Cruz. The first [proofs-of-concept](https://dl.acm.org/doi/abs/10.1145/3616391.3622771) that leveraged NSB included decentralized federated learning and autonomous vehicle platooning. While core development is active as of February 2026, we invite collaborators and users to help us in that process and to develop domain-specific and/or usage-specific solutions.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -2,6 +2,23 @@
 
 C++ 17 is required to use the client API.
 
+## Table of Contents
+- [Setting Up the Library](#setting-up-the-library)
+- [Compiling Your Project with NSB](#compiling-your-project-with-nsb)
+- [Basic API Usage](#basic-api-usage)
+  - [Notes on the C++ Implementation](#notes-on-the-c-implementation)
+    - [Representing Bytestrings as `string`](#representing-bytestrings-as-string)
+    - [The `MessageEntry` Object](#the-messageentry-object)
+  - [NSB Application Client (`NSBAppClient`)](#nsb-application-client-nsbappclient)
+    - [Sending Payloads (`send`)](#sending-payloads-send)
+    - [Receiving Payloads (`receive`)](#receiving-payloads-receive)
+  - [NSB Simulator Client (`NSBSimClient`)](#nsb-simulator-client-nsbsimclient)
+    - [Fetching Payloads for Simulation (`fetch`)](#fetching-payloads-for-simulation-fetch)
+    - [Posting an Arrived Payload (`post`)](#posting-an-arrived-payload-post)
+- [Notes](#notes)
+  - [Additional Documentation via Doxygen](#additional-documentation-via-doxygen)
+  - [Use of AI](#use-of-ai)
+
 ## Setting Up the Library
 When you build NSB with CMake, the client library is automatically compiled and 
 can be found in the _build_ directory as **libnsb.\***. Upon installation, the 

--- a/cpp/rabbit/README.md
+++ b/cpp/rabbit/README.md
@@ -2,6 +2,21 @@
 
 C++ client library for NSB using RabbitMQ as the message transport. Provides `NSBAppClientRMQ` (application send/receive) and `NSBSimClientRMQ` (simulator fetch/post), plus a standalone C++ daemon.
 
+## Table of Contents
+- [Prerequisites](#prerequisites)
+  - [macOS (Homebrew)](#macos-homebrew)
+  - [RabbitMQ Broker](#rabbitmq-broker)
+- [Build](#build)
+- [Run](#run)
+  - [RabbitMQ backend](#rabbitmq-backend)
+  - [Socket backend](#socket-backend)
+- [API Overview](#api-overview)
+  - [Class Hierarchy](#class-hierarchy)
+  - [NSBAppClientRMQ](#nsbappclientrmq)
+  - [NSBSimClientRMQ](#nsbsimclientrmq)
+  - [NSBDaemonRMQ](#nsbdaemonrmq)
+  - [Config & MessageEntry](#config--messageentry)
+
 ## Prerequisites
 
 ### macOS (Homebrew)

--- a/examples/ns3/README.md
+++ b/examples/ns3/README.md
@@ -1,3 +1,8 @@
+## Table of Contents
+- [Installing ns-3](#installing-ns-3)
+- [Linking NSB with ns-3 through the CMakeLists.txt](#linking-nsb-with-ns-3-through-the-cmakeliststxt)
+- [Testing with a simple AppClient script](#testing-with-a-simple-appclient-script)
+
 ### **Installing ns-3** 
 
 Here we cover the detailed steps for integrating NSB with the ns-3

--- a/examples/omnet/README.md
+++ b/examples/omnet/README.md
@@ -1,3 +1,12 @@
+## Table of Contents
+- [Installation Steps for OMNeT++](#installation-steps-for-omnet)
+- [nsb_omnet_basic](#nsb_omnet_basic)
+  - [Steps to run the OMNeT++ simulation](#steps-to-run-the-omnet-simulation)
+- [nsb_omnet_inet](#nsb_omnet_inet)
+  - [Installation Steps for INET](#installation-steps-for-inet)
+  - [Steps to run the simulation](#steps-to-run-the-simulation)
+- [Note](#note)
+
 ### **Installation Steps for OMNeT++**
 
 **Highly recommended** to install

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,19 @@
 # NSB Client API in Python
 
+## Table of Contents
+- [Adding the Client Module](#adding-the-client-module)
+- [Basic API Usage](#basic-api-usage)
+  - [The MessageEntry Object](#the-messageentry-object)
+  - [NSB Application Client (NSBAppClient)](#nsb-application-client-nsbappclient)
+    - [Sending Payloads (send)](#sending-payloads-send)
+    - [Receiving Payloads (receive)](#receiving-payloads-receive)
+    - [Listening for Payloads (listen)](#listening-for-payloads-listen)
+  - [NSB Simulator Client (NSBSimClient)](#nsb-simulator-client-nsbsimclient)
+    - [Fetching Payloads for Simulation (fetch)](#fetching-payloads-for-simulation-fetch)
+    - [Listening to Fetch Payloads (listen)](#listening-to-fetch-payloads-listen)
+    - [Posting an Arrived Payload (post)](#posting-an-arrived-payload-post)
+- [Additional Documentation via Doxygen](#additional-documentation-via-doxygen)
+
 ## Adding the Client Module
 _Installable Python package coming soon._
 

--- a/rabbit/README.md
+++ b/rabbit/README.md
@@ -1,5 +1,35 @@
 # NSB RabbitMQ Implementation
 
+## Table of Contents
+- [Architecture Overview](#architecture-overview)
+  - [Key Architectural Advantage](#key-architectural-advantage)
+  - [Key Components](#key-components)
+  - [Queue Architecture](#queue-architecture)
+  - [Message Flow](#message-flow)
+    - [Client Initialization](#client-initialization)
+    - [Message Sending (App Client)](#message-sending-app-client)
+    - [Message Receiving (App Client)](#message-receiving-app-client)
+    - [Message Fetching (Simulator Client)](#message-fetching-simulator-client)
+- [Usage](#usage)
+  - [Starting the Daemon](#starting-the-daemon)
+  - [Creating an Application Client (RabbitMQ-only module)](#creating-an-application-client-rabbitmq-only-module)
+  - [Creating a Simulator Client (RabbitMQ-only module)](#creating-a-simulator-client-rabbitmq-only-module)
+  - [Using the Unified Client (recommended)](#using-the-unified-client-recommended)
+  - [Asynchronous Operations](#asynchronous-operations)
+- [Configuration](#configuration)
+  - [System Modes](#system-modes)
+  - [Simulator Modes](#simulator-modes)
+  - [Database Configuration](#database-configuration)
+- [Cross-Language Interoperability](#cross-language-interoperability)
+- [Architecture Differences from Socket Implementation](#architecture-differences-from-socket-implementation)
+  - [Similarities](#similarities)
+  - [Differences from Socket Implementation](#differences-from-socket-implementation)
+- [Dependencies](#dependencies)
+- [Testing](#testing)
+  - [Test Suite](#test-suite)
+  - [Examples](#examples)
+  - [Quick Inline Test](#quick-inline-test)
+
 ## Architecture Overview
 
 ### Key Architectural Advantage


### PR DESCRIPTION
## Description
Added Table of Contents to all 7 README files across the repository to improve documentation navigation and usability.

## Changes
- Added TOC to root README.md (Installation, Basic Usage, Extensibility, License)
- Added TOC to python/README.md (API documentation sections)
- Added TOC to cpp/README.md (C++ API documentation)
- Added TOC to rabbit/README.md (RabbitMQ implementation)
- Added TOC to cpp/rabbit/README.md (C++ RabbitMQ implementation)
- Added TOC to examples/omnet/README.md (OMNeT++ simulator examples)
- Added TOC to examples/ns3/README.md (ns-3 simulator examples)